### PR TITLE
Add support for custom headIdx names, fixes #2

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -33,14 +33,14 @@ export default class ExtendableHeads extends Plugin  {
 		
 		
 		const customIdx = {};
-		const customNameMapping = {};
+		let customNameMapping = {};
 
 		for (let index = 0; index < headIdx.length; ++index) {
 			const head = headIdx[index];
 			customIdx[head.id] = startIndex + index;
 			if(head.name) {
 				if(head.name in customNameMapping) {
-					console.warn(`Warning: duplicate name entry for custom head ${head.name}`);
+					console.warn(`Warning: duplicate name entry "${head.name}" for custom head of ${head.id}`);
 				} else {
 					customNameMapping[head.name] = startIndex + index;
 				}
@@ -84,13 +84,22 @@ export default class ExtendableHeads extends Plugin  {
 			}
 		});
 
+		function customNameToHeadIdx(headIdx) {
+			if(typeof headIdx == "string" && headIdx in customNameMapping) {
+				return customNameMapping[headIdx];
+			}
+			return headIdx;
+		}
+
+		sc.PartyMemberModel.inject({
+			getHeadIdx() {
+				return customNameToHeadIdx(this.parent())
+			}
+		})
+		
 		ig.ENTITY.Enemy.inject({
 			getHeadIdx() {
-				let headIdx = this.parent();
-				if(typeof headIdx == "string" && headIdx in customNameMapping) {
-					return customNameMapping[headIdx]
-				}
-				return headIdx;
+				return customNameToHeadIdx(this.parent())
 			}
 		})
 
@@ -194,5 +203,4 @@ export default class ExtendableHeads extends Plugin  {
 			})
 		});
 	}
-
 }

--- a/plugin.js
+++ b/plugin.js
@@ -33,10 +33,18 @@ export default class ExtendableHeads extends Plugin  {
 		
 		
 		const customIdx = {};
+		const customNameMapping = {};
 
 		for (let index = 0; index < headIdx.length; ++index) {
 			const head = headIdx[index];
 			customIdx[head.id] = startIndex + index;
+			if(head.name) {
+				if(head.name in customNameMapping) {
+					console.warn(`Warning: duplicate name entry for custom head ${head.name}`);
+				} else {
+					customNameMapping[head.name] = startIndex + index;
+				}
+			}
 		}
 		sc.PlayerConfig.inject({
 			onload: function(config) {
@@ -75,6 +83,16 @@ export default class ExtendableHeads extends Plugin  {
 				}
 			}
 		});
+
+		ig.ENTITY.Enemy.inject({
+			getHeadIdx() {
+				let headIdx = this.parent();
+				if(typeof headIdx == "string" && headIdx in customNameMapping) {
+					return customNameMapping[headIdx]
+				}
+				return headIdx;
+			}
+		})
 
 		const img = new ig.Image("media/gui/severed-heads.png");
 		img.addLoadListener({


### PR DESCRIPTION
When defining custom heads in `headIdx.json.patch`, you may now specify a `name` property which will be able to be used in party member and enemy files to indicate which severed head to use, similar to how item-api handles custom items.

How to use, using [Xenon's Triblader Mod](https://github.com/XenonA7/xenons-triblader-mod) as a base:
![image](https://github.com/CCDirectLink/extendable-severed-heads/assets/49847844/198e8a24-0c02-4f42-befe-d16c14cd60ce)

Simply add a `name` property to the head definition in `headIdx.json.patch`, and in an enemy file (or player config definition):
![image](https://github.com/CCDirectLink/extendable-severed-heads/assets/49847844/cc92fbee-b240-4aae-91ff-589877d47d0f)
